### PR TITLE
Allow single-quoted multiline strings

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -26,13 +26,14 @@ const TOKENS = {
       'UnquotedString',
       'EmptyString',
       'QuotedString',
+      'SingleQuotedString'
     ],
   },
 
   UnquotedString: [{ type: 'SafeChar', flatten: true }, { type: 'UnquotedStringChars', optional: true, flatten: true }],
 
   // any char except newline and ", " is reserved for future quoted strings.
-  SafeChar: [/[^\n"]/],
+  SafeChar: [/[^\n"']/],
   UnquotedStringChars: [/[^\\\n]/, { type: 'UnquotedStringChars', optional: true, flatten: true }],
 
   // TODO: This type should not exist, but QuotedString[1].optional does not work. this is a hotfix.
@@ -45,7 +46,13 @@ const TOKENS = {
       'EscapedChars',
     ],
   },
+  SingleQuotedString: ["'", { type: 'SingleQuotedStringChars', optional: true }, "'"],
+  SingleQuotedStringChars: [{ type: 'SingleQuotedStringChar', flatten: true }, { type: 'SingleQuotedStringChars', optional: true, flatten: true }],
+  SingleQuotedStringChar: {
+    $or: ['UnescapedSingleQuotedStringChar']
+  },
   UnescapedQuotedStringChar: [/[^\\"]/],
+  UnescapedSingleQuotedStringChar: [/[^']/],
   EscapedChars: {
     replacer(val) {
       switch (val[0]) {

--- a/src/serialize.js
+++ b/src/serialize.js
@@ -17,10 +17,17 @@ export default function serialize(obj) {
       }
     }
 
-    serializedEntry += `${key}=${JSON.stringify(value)}`;
+    serializedEntry += `${key}=${serializeString(value)}`;
 
     serializedDoc.push(serializedEntry);
   }
 
-  return serializedDoc.join('\n\n');
+  return serializedDoc.join('\n');
+}
+
+function serializeString(val) {
+  if (val.includes('\n') && !val.includes("'")) {
+    return `'${val}'`;
+  }
+  return JSON.stringify(val)
 }


### PR DESCRIPTION
Some shells and tooling expect multiline env vars to be single-quoted. It is also particularly cumbersome when you have a JSON literal as the variable's value: you would need to escape _every `"`_ without single quotes

This PR adds support for parsing single-quoted multiline strings, and serializes multiline strings that don't include `'` in their value to single-quoted mulitline strings.

It also joins declarations with a single newline instead of two. This is more of a personal preference thing though, so maybe making this configurable would be more appropriate.
This is there mainly because this PR comes from a yarn patch of the package I did to use it directly.

